### PR TITLE
Correct getlogin() bug under Linux

### DIFF
--- a/dials/base_logger.py
+++ b/dials/base_logger.py
@@ -1,4 +1,5 @@
 import os
+import getpass
 import sys
 import logging
 from logging.handlers import RotatingFileHandler
@@ -73,7 +74,7 @@ def set_logger_level(level='info'):
 log_formatter = logging.Formatter('%(asctime)s %(levelname)s %(funcName)s(%(lineno)d) %(message)s')
 if sys.platform == "linux" or sys.platform == "linux2":
     # linux
-    logFile = f'/home/{os.getlogin()}/vudials.log'
+    logFile = f'/home/{getpass.getuser()}/vudials.log'
 elif sys.platform == "darwin":
     # OS Xcat
     logFile = f'/home/{os.getlogin()}/vudials.log'


### PR DESCRIPTION
It seems that there a bug with os.getLogin() function under linux :

$ python server.py
Traceback (most recent call last):
  File "/home/user/Apps/VU-Dials/VU-Server/server.py", line 8, in <module>
    from dials.base_logger import logger, set_logger_level
  File "/home/user/VU-Dials/VU-Server/dials/base_logger.py", line 76, in <module>
    logFile = f'/home/{os.getlogin()}/vudials.log'
OSError: [Errno 6] No such device or address

- - - - - - - -

The function getpass.getuser() is a workaround (https://docs.python.org/3/library/getpass.html)