### PR TITLE
Change log location OSX

### DIFF
--- a/dials/base_logger.py
+++ b/dials/base_logger.py
@@ -72,9 +72,13 @@ def set_logger_level(level='info'):
 '''
 # Basic logger setup
 log_formatter = logging.Formatter('%(asctime)s %(levelname)s %(funcName)s(%(lineno)d) %(message)s')
-# Linux and MacOS
-if sys.platform in ["linux", "linux2", "darwin"]:
+# Linux
+if sys.platform in ["linux", "linux2"]:
     logFile = f'/home/{getpass.getuser()}/vudials.log'
+
+elif sys.platform == "darwin":
+    logFile = f'~/Library/Logs/vudials/vudials.log'
+
 # Windows
 elif sys.platform == "win32":
     logFile = os.path.join(os.path.expanduser(os.getenv('USERPROFILE')), 'vudials', 'vudials.log')

--- a/dials/base_logger.py
+++ b/dials/base_logger.py
@@ -76,6 +76,7 @@ log_formatter = logging.Formatter('%(asctime)s %(levelname)s %(funcName)s(%(line
 if sys.platform in ["linux", "linux2"]:
     logFile = f'/home/{getpass.getuser()}/vudials.log'
 
+# MacOS
 elif sys.platform == "darwin":
     logFile = f'~/Library/Logs/vudials/vudials.log'
 


### PR DESCRIPTION
Current method causes a `OSError: [Errno 45] Operation not supported osx`. This pr changes the directory to `~/Library/Logs/vudials/vudials.log` for logging which is the more osx way to manage this. 

See https://stackoverflow.com/questions/70638430/which-directory-is-the-best-for-saving-logs#:~:text=If%20each%20user%20should%20see,Logs%20is%20the%20right%20place. 