### PR TITLE
Configure filesystem paths from the command line

### DIFF
--- a/database.py
+++ b/database.py
@@ -6,14 +6,12 @@ from dials.base_logger import logger
 class DialsDB:
     connection = None
 
-    def __init__(self, database_file='vudials.db', init_if_missing=False):
-        # database_path = os.path.join(os.path.expanduser('~'), 'KaranovicResearch', 'vudials')
-        database_path = os.path.join(os.path.dirname(__file__))
+    def __init__(self, database_path, init_if_missing=False):
 
         if not os.path.exists(database_path):
             os.makedirs(database_path)
 
-        self.database_file =  os.path.join(database_path, database_file)
+        self.database_file = os.path.join(database_path, 'vudials.db')
         logger.info(f"VU1 Database file: {self.database_file}")
 
         if not os.path.exists(self.database_file) and not init_if_missing:

--- a/dials/base_logger.py
+++ b/dials/base_logger.py
@@ -56,7 +56,42 @@ def default_formatter():
 
     return logging.Formatter(fmt, "%b %d %Y %H:%M:%S")
 
-def set_logger_level(level='info'):
+# Shared stdout logger
+logger = logging.getLogger('kr_gauge_root')
+
+def default_log_file():
+    # Linux
+    if sys.platform in ["linux", "linux2"]:
+        logFile = f'/home/{getpass.getuser()}/KaranovicResearch/vudials/server.log'
+
+    # MacOS
+    elif sys.platform == "darwin":
+        logFile = f'~/Library/Logs/KaranovicResearch/vudials/server.log'
+
+    # Windows
+    elif sys.platform == "win32":
+        logFile = os.path.join(os.path.expanduser(os.getenv('USERPROFILE')), 'KaranovicResearch', 'vudials', 'server.log')
+
+def setup_logger(log_file, level='info'):
+    '''
+        Shared stdout logger and logging to file
+    '''
+    # Basic logger setup
+    log_formatter = logging.Formatter('%(asctime)s %(levelname)s %(funcName)s(%(lineno)d) %(message)s')
+
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    log_file_handler = RotatingFileHandler(log_file, mode='a', maxBytes=1*1024*1024, backupCount=2, encoding=None, delay=0)
+    log_file_handler.setLevel(logging.DEBUG)
+    log_file_handler.setFormatter(log_formatter)
+
+    logger.setLevel(logging.INFO)
+    logger.addHandler(log_file_handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setFormatter(default_formatter())
+    logger.addHandler(handler)
+
     if level.lower() == 'info':
         logging.getLogger('kr_gauge_root').setLevel("INFO")
         logger.info("Logging level: INFO")
@@ -67,34 +102,3 @@ def set_logger_level(level='info'):
         logger.setLevel(logging.INFO)
         logger.info("Logging level: INFO")
 
-'''
-    Shared stdout logger and logging to file
-'''
-# Basic logger setup
-log_formatter = logging.Formatter('%(asctime)s %(levelname)s %(funcName)s(%(lineno)d) %(message)s')
-# Linux
-if sys.platform in ["linux", "linux2"]:
-    logFile = f'/home/{getpass.getuser()}/KaranovicResearch/vudials/server.log'
-
-# MacOS
-elif sys.platform == "darwin":
-    logFile = f'~/Library/Logs/KaranovicResearch/vudials/server.log'
-
-# Windows
-elif sys.platform == "win32":
-    logFile = os.path.join(os.path.expanduser(os.getenv('USERPROFILE')), 'KaranovicResearch', 'vudials', 'server.log')
-
-os.makedirs(os.path.dirname(logFile), exist_ok=True)
-log_file_handler = RotatingFileHandler(logFile, mode='a', maxBytes=1*1024*1024, backupCount=2, encoding=None, delay=0)
-log_file_handler.setLevel(logging.DEBUG)
-log_file_handler.setFormatter(log_formatter)
-
-# Shared stdout logger
-logger = logging.getLogger('kr_gauge_root')
-logger.setLevel(logging.INFO)
-logger.addHandler(log_file_handler)
-logger.setLevel(logging.INFO)
-logger.propagate = False
-handler = logging.StreamHandler(stream=sys.stderr)
-handler.setFormatter(default_formatter())
-logger.addHandler(handler)

--- a/server_config.py
+++ b/server_config.py
@@ -16,10 +16,10 @@ class ServerConfig:
     api_keys = {}
     database = None
 
-    def __init__(self, config_file='config.yaml'):
-        self.config_path =  os.path.join(os.path.dirname(__file__), config_file)
+    def __init__(self, config_path, state_path):
+        self.config_path = config_path
         logger.info(f"VU1 config yaml file: {self.config_path}")
-        self.database = db.DialsDB(init_if_missing=True)
+        self.database = db.DialsDB(database_path=state_path, init_if_missing=True)
         self._load_config()     # Load configuration from .yaml file
         self._load_API_keys()   # Load API keys from `api_keys` section
         self.debug_config()


### PR DESCRIPTION
Currently, all paths used by the server are hard-coded to paths in the directory where the server source code is located. On Unix systems, it's preferable to store state, configuration, and log files in different directories. Therefore, this commit adds the following new command-line arguments to configure these paths:

- `--state-dir`: configures the directory where the database and uploaded image files are stored.
- `--config-path`: configures the path to the config file.
- `--log-path`: configures the path to the directory where log files will be written.
- `--lock-path`: configures the path to the directory where the server will store its PID lock file.

If these command-line arguments are not provided, the server behaves identically to the way it does today.

Fixes #20 