### PR TITLE
2024-02 - General improvements

### DIFF
--- a/database.py
+++ b/database.py
@@ -5,6 +5,7 @@ from dials.base_logger import logger
 
 class DialsDB:
     connection = None
+    database_changes = 0
 
     def __init__(self, database_file='vudials.db', init_if_missing=False):
         # database_path = os.path.join(os.path.expanduser('~'), 'KaranovicResearch', 'vudials')
@@ -211,7 +212,8 @@ class DialsDB:
 
 
     def _more_than_one_changed(self):
-        if self.connection.total_changes > 0:
+        if self.connection.total_changes > self.database_changes:
+            self.database_changes = self.connection.total_changes
             return True
         return False
 

--- a/dial_driver.py
+++ b/dial_driver.py
@@ -300,7 +300,7 @@ class DialSerialDriver(SerialHardware):
     def dial_easing_get_config(self, dialID):
         easing = { 'dial_step':0, 'dial_period':0, 'backlight_step':0, 'backlight_period':0 }
         logger.debug(f"@dial_easing_get_config(dialID={dialID})")
-        ret = self._sendCommand(self.commands.COMM_CMD_GET_EASING_CONFIG, self.data_type.COMM_DATA_NONE)
+        ret = self._sendCommand(self.commands.COMM_CMD_GET_EASING_CONFIG, self.data_type.COMM_DATA_SINGLE_VALUE, 1, dialID)
         ret = self._convert_hex_str_to_byte_array(ret)
 
         easing['dial_step']         = int(ret[0]) << 24 | int(ret[1]) << 16 | int(ret[2]) << 8 | int(ret[3])

--- a/server_config.py
+++ b/server_config.py
@@ -138,11 +138,14 @@ class ServerConfig:
 
     def update_dial_db_cell(self, dial_uid, cell, value):
         try:
-            self.database.dial_update_cell(dial_uid=dial_uid, cell=cell, value=value)
-            self.dials[dial_uid][cell] = value
+            ret = self.database.dial_update_cell(dial_uid=dial_uid, cell=cell, value=value)
+            if ret:
+                self.dials[dial_uid][cell] = value
+                return True
+            return False
         except Exception as e:
             logger.error(e)
-            return
+            return False
 
     def update_dial_db_cell_with_dict(self, dial_uid, values_dict):
         try:

--- a/server_dial_handler.py
+++ b/server_dial_handler.py
@@ -321,7 +321,6 @@ class ServerDialHandler:
             return False
 
         dial_info = self.server_config.dial_fetch_db_info(dial_uid)
-        logger.error(dial_info)
 
         self.dials[dial_uid]['fw_hash'] = dial_info['dial_build_hash']
         self.dials[dial_uid]['fw_version'] = dial_info['dial_fw_version']

--- a/www/views/dial.html
+++ b/www/views/dial.html
@@ -162,6 +162,16 @@
                       </div>
                     </div>
 
+                    <div id="dial-name-rules" style="display: none;">
+                        <p>Dial name should be between 3 and 30 characters long</p>
+                        <p>It should contain only <br>Letters `A-Z`<br>Numbers `0-9`<br>Dash `-`<br>Underscore `_`<br>Space ` `</p>
+                    </div>
+
+                    <div id="dial-server-issue" style="display: none;">
+                        <p>Server reports dial is unavailable. Please check if your dial is connected and restart VU server.</p>
+                        <p>Sever message: <span id="dial-server-issue-message"></span></p>
+                    </div>
+
                   </div>
                 </div>
                 </div>


### PR DESCRIPTION
This PR addresses adds general improvements to the VU Server behavior.

In particular:
- Added dialog box that alerts end user via message box. This is to notify the user about important events like VU Server can not find hub, application close/crash etc
- Updated dial name requirements: Name should be between 3-30 characters and only contain A-Z, 0-9, hyphen, underscore and space
- Added server-side validation of dial name and appropriate HTTP error code and JSON message
- Added client-side validation of dial name and appropriate UI feedback
- Added graceful dial shutdown just before VU Server shuts down (set dial value to 0% and backlight to off)
- Updated database driver to account for persistent connection when counting rows affected by last query
- Updated `dial_easing_get_config` function signature

This PR address issues #11 #14 #17 #21 

Thank you all for contributing!
Let's turn the dials to 11! :)